### PR TITLE
feat: Add upgradeProtocol utility

### DIFF
--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -12,6 +12,7 @@ import {
   resolveUrl,
   resolveFeedProtocol,
   addMissingProtocol,
+  upgradeProtocol,
 } from 'feedcanon'
 ```
 
@@ -149,4 +150,42 @@ addMissingProtocol('//example.com/feed')
 
 addMissingProtocol('example.com/feed')
 // 'https://example.com/feed'
+```
+
+---
+
+### `upgradeProtocol()`
+
+Swaps an existing HTTP(S) protocol on a URL. Unlike `addMissingProtocol`, which only acts when the protocol is absent, this rewrites the scheme when one is already present.
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | `string` | — | The URL to process |
+| `protocol` | `'http' \| 'https'` | `'https'` | Target protocol |
+
+#### Returns
+
+`string` — The URL with the protocol swapped, or unchanged if no matching HTTP(S) scheme is present.
+
+#### Notes
+
+- Case-insensitive on the matched protocol (`HTTP://` is upgraded).
+- Only the leading scheme is touched; an `http://` substring later in the path or query is left alone.
+- Protocol-relative URLs (`//host`) and non-HTTP schemes (`mailto:`, `data:`, `ftp://`, `feed://`) are left unchanged.
+
+#### Example
+
+```typescript
+import { upgradeProtocol } from 'feedcanon'
+
+upgradeProtocol('http://example.com/feed')
+// 'https://example.com/feed'
+
+upgradeProtocol('https://example.com/feed', 'http')
+// 'http://example.com/feed'
+
+upgradeProtocol('//example.com/feed')
+// '//example.com/feed' (unchanged)
 ```

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -30,4 +30,5 @@ export {
   normalizeUrl,
   resolveFeedProtocol,
   resolveUrl,
+  upgradeProtocol,
 } from './utils.js'

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeUrl,
   resolveFeedProtocol,
   resolveUrl,
+  upgradeProtocol,
 } from './utils.js'
 
 describe('resolveFeedProtocol', () => {
@@ -505,6 +506,79 @@ describe('addMissingProtocol', () => {
       expect(addMissingProtocol(' example.com')).toBe(' example.com')
       expect(addMissingProtocol('\texample.com')).toBe('\texample.com')
       expect(addMissingProtocol('\nexample.com')).toBe('\nexample.com')
+    })
+  })
+})
+
+describe('upgradeProtocol', () => {
+  describe('default (upgrade to https)', () => {
+    const values = [
+      { value: 'http://example.com/feed', expected: 'https://example.com/feed' },
+      {
+        value: 'http://example.com:8080/path?a=1#frag',
+        expected: 'https://example.com:8080/path?a=1#frag',
+      },
+      { value: 'http://user:pass@example.com/', expected: 'https://user:pass@example.com/' },
+      { value: 'http://localhost/', expected: 'https://localhost/' },
+      { value: 'http://192.168.1.1/api', expected: 'https://192.168.1.1/api' },
+    ]
+
+    for (const { value, expected } of values) {
+      it(`should upgrade ${value} to ${expected}`, () => {
+        expect(upgradeProtocol(value)).toBe(expected)
+      })
+    }
+
+    it('should be case-insensitive on the protocol', () => {
+      expect(upgradeProtocol('HTTP://example.com/feed')).toBe('https://example.com/feed')
+      expect(upgradeProtocol('Http://example.com/feed')).toBe('https://example.com/feed')
+    })
+
+    it('should only touch the leading protocol, not occurrences inside the URL', () => {
+      const value = 'http://proxy.example/?target=http://other.example/page'
+      const expected = 'https://proxy.example/?target=http://other.example/page'
+
+      expect(upgradeProtocol(value)).toBe(expected)
+    })
+  })
+
+  describe('downgrade to http', () => {
+    it('should rewrite https:// to http://', () => {
+      expect(upgradeProtocol('https://example.com/feed', 'http')).toBe('http://example.com/feed')
+    })
+
+    it('should be case-insensitive on the protocol', () => {
+      expect(upgradeProtocol('HTTPS://example.com/feed', 'http')).toBe('http://example.com/feed')
+    })
+
+    it('should leave http:// unchanged', () => {
+      expect(upgradeProtocol('http://example.com/feed', 'http')).toBe('http://example.com/feed')
+    })
+  })
+
+  describe('unchanged inputs', () => {
+    it('should leave https:// unchanged when upgrading to https', () => {
+      expect(upgradeProtocol('https://example.com/feed')).toBe('https://example.com/feed')
+    })
+
+    it('should leave protocol-relative URLs unchanged', () => {
+      expect(upgradeProtocol('//example.com/feed')).toBe('//example.com/feed')
+    })
+
+    it('should leave non-http schemes unchanged', () => {
+      expect(upgradeProtocol('mailto:user@example.com')).toBe('mailto:user@example.com')
+      expect(upgradeProtocol('data:image/png;base64,iVBOR')).toBe('data:image/png;base64,iVBOR')
+      expect(upgradeProtocol('ftp://example.com/file')).toBe('ftp://example.com/file')
+      expect(upgradeProtocol('feed://example.com/rss.xml')).toBe('feed://example.com/rss.xml')
+    })
+
+    it('should leave bare domains and paths unchanged', () => {
+      expect(upgradeProtocol('example.com/feed')).toBe('example.com/feed')
+      expect(upgradeProtocol('/path/to/feed')).toBe('/path/to/feed')
+    })
+
+    it('should leave an empty string unchanged', () => {
+      expect(upgradeProtocol('')).toBe('')
     })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,9 @@ const httpsLetterRegex = /s/i
 const protocolPrefixRegex = /^https?:\/\//
 const wwwPrefixRegex = /^www\./
 
+const httpProtocolRegex = /^http:\/\//i
+const httpsProtocolRegex = /^https:\/\//i
+
 // Pre-compiled patterns for fixMalformedProtocol.
 // Fast path: valid http(s):// followed by hostname char (excludes lone 'w' to avoid partial 'www').
 const validUrlRegex = /^https?:\/\/(?:www\.|[a-vx-z0-9])/i
@@ -178,6 +181,20 @@ export const addMissingProtocol = (url: string, protocol: 'http' | 'https' = 'ht
   }
 
   return `${protocol}://${url}`
+}
+
+// Swaps an existing HTTP(S) protocol on a URL. Unlike `addMissingProtocol`,
+// which only acts when the protocol is absent, this rewrites the scheme
+// when one is already present. Protocol-relative URLs (`//host`) and
+// non-HTTP schemes (`mailto:`, `data:`, `ftp://`) are left unchanged.
+// Case-insensitive on the matched protocol; only the leading scheme is
+// touched, not any later `http://` substring inside the path or query.
+export const upgradeProtocol = (url: string, protocol: 'http' | 'https' = 'https'): string => {
+  if (protocol === 'https') {
+    return url.replace(httpProtocolRegex, 'https://')
+  }
+
+  return url.replace(httpsProtocolRegex, 'http://')
 }
 
 // Resolves a URL by converting feed protocols, resolving relative URLs,


### PR DESCRIPTION
## Summary

Adds `upgradeProtocol(url, protocol = 'https')` to the URL-protocol family in `src/utils.ts`, alongside `fixMalformedProtocol`, `resolveFeedProtocol`, and `addMissingProtocol`.

The distinction:
- `addMissingProtocol` — adds a scheme when **none** is present.
- `upgradeProtocol` — swaps an **existing** scheme.

Same inline `.replace('http://', 'https://')` pattern currently appears twice in `src/index.ts` (lines 180, 265). Not deduped in this PR to keep scope tight — happy to do it in a follow-up.

## Behavior

- Case-insensitive on the matched protocol (`HTTP://` upgrades).
- Only the leading scheme is touched; an `http://` substring later in path/query is left alone.
- Protocol-relative URLs (`//host`) and non-HTTP schemes (`mailto:`, `data:`, `ftp://`, `feed://`) are left unchanged.
- Symmetric: pass `'http'` to downgrade.

## Mergeability into `next`

`src/utils.ts`, `src/utils.test.ts`, `src/exports.ts`, and `docs/reference/utilities.md` are byte-identical between `main` and `next` today (verified with `git diff main next`). So after this lands on `main`, a routine `git merge main` into `next` (the existing pattern, e.g. ae3e5e4) will be conflict-free.