### PR TITLE
feat: Replace stripQueryParams option with cleanUrlFn

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,10 @@
         "feedsmith": "^3.0.0-beta.4",
         "kvalita": "^1.14.0",
         "tsdown": "^0.22.2",
-        "urlpurify": "^1.0.0",
         "vitepress": "^2.0.0-alpha.17",
       },
       "peerDependencies": {
         "feedsmith": "^3.0.0-beta.4",
-        "urlpurify": "^1.0.0",
       },
     },
   },
@@ -987,8 +985,6 @@
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
-
-    "urlpurify": ["urlpurify@1.0.0", "", {}, "sha512-bZGvll5fbtdhsO+Ev5kgZWRa0hJK40/+0secZ1Q9SXYha77pS8Y/zzF6y897BlzE1et4xBcLy7jwhX6eX5aTKg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/docs/guides/customization/url-tiers.md
+++ b/docs/guides/customization/url-tiers.md
@@ -14,7 +14,7 @@ Default tiers:
 4. **Tier 4** — Keep www and trailing slash, keep query
 
 ::: info
-Tracking parameters are stripped separately via the `stripQueryParams` option in `FindCanonicalOptions`, not per-tier. This ensures consistent param stripping across all tiers.
+In addition to the structural tiers, you can plug extra cleaning into the `cleanUrlFn` option in `FindCanonicalOptions`: strip tracking params, unwrap redirect wrappers, or apply any custom rewrite. It runs once before candidate generation, so the cleanup stays consistent across all tiers. The [urlpurify](https://github.com/macieklamberski/urlpurify) package provides ready-made functions for this.
 :::
 
 ## Normalization Options
@@ -31,7 +31,6 @@ Each tier accepts all `NormalizeOptions` except `stripQueryParams`:
 | `collapseSlashes` | `true` | `///` → `/` |
 | `stripHash` | `true` | Remove `#fragment` |
 | `sortQueryParams` | `true` | Sort params alphabetically |
-| ~~`stripQueryParams`~~ | ~~—~~ | ~~Handled at top level, not per-tier~~ |
 | `stripQuery` | `false` | Remove entire query string |
 | `stripEmptyQuery` | `true` | Remove empty `?` |
 | `normalizeEncoding` | `true` | Normalize `%XX` encoding |
@@ -75,20 +74,16 @@ const url = await findCanonical('https://example.com/feed', {
 })
 ```
 
-### Custom Stripped Params
+### Strip Tracking Params
 
-Add your own tracking parameters (at the top level, not per-tier):
+Clean tracking params before candidate generation (at the top level, not per-tier):
 
 ```typescript
 import { findCanonical } from 'feedcanon'
-import { defaultTrackingParams } from 'urlpurify'
+import { stripTrackingParams } from 'urlpurify'
 
 const url = await findCanonical('https://example.com/feed', {
-  stripQueryParams: [
-    ...defaultTrackingParams,
-    'my_tracking_param',
-    'internal_ref',
-  ],
+  cleanUrlFn: stripTrackingParams,
   tiers: [
     { stripWww: true, stripTrailingSlash: true },
     { stripTrailingSlash: true },
@@ -102,13 +97,9 @@ Keep all query parameters (no stripping):
 
 ```typescript
 const url = await findCanonical('https://example.com/feed', {
-  stripQueryParams: [], // Keep all params
   tiers: [
     { stripWww: true, stripTrailingSlash: true },
   ],
 })
 ```
 
-## Default Stripped Parameters
-
-Feedcanon strips 150+ tracking parameters by default, sourced from the [urlpurify](https://github.com/macieklamberski/urlpurify) package. See [`defaultTrackingParams`](https://github.com/macieklamberski/urlpurify/blob/main/src/params.ts) for the complete list.

--- a/docs/reference/find-canonical.md
+++ b/docs/reference/find-canonical.md
@@ -23,11 +23,11 @@ Finds the canonical URL for a given feed URL by fetching, parsing, and testing U
 |--------|------|---------|-------------|
 | `parser` | [`ParserAdapter`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L9) | [`defaultParser`](https://github.com/macieklamberski/feedcanon/blob/main/src/defaults.ts#L249) | Custom feed parser. See [Feed Parsing](/guides/customization/feed-parsing) |
 | `fetchFn` | [`FetchFn`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L101) | [`defaultFetch`](https://github.com/macieklamberski/feedcanon/blob/main/src/defaults.ts#L235) | Custom fetch function. See [Data Fetching](/guides/customization/data-fetching) |
+| `cleanUrlFn` | `(url: string) => string` | — | Clean URLs before candidate generation (e.g. [urlpurify](https://github.com/macieklamberski/urlpurify)) |
 | `existsFn` | [`ExistsFn`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L90) | — | Database lookup function. See [Using Callbacks](/guides/callbacks#onexists) |
 | `tiers` | [`Tier[]`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L47) | [`defaultTiers`](https://github.com/macieklamberski/feedcanon/blob/main/src/defaults.ts#L315) | URL normalization tiers. See [URL Tiers](/guides/customization/url-tiers) |
 | `rewrites` | [`Rewrite[]`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L16) | `[]` | URL rewrites. See [URL Rewrites](/guides/customization/url-rewrites) |
 | `probes` | [`Probe[]`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L22) | — | URL probes for testing alternate URL forms. See [URL Probes](/guides/customization/url-probes) |
-| `stripQueryParams` | `string[]` | [`defaultTrackingParams`](https://github.com/macieklamberski/urlpurify/blob/main/src/params.ts) | Query params to strip |
 | `onFetch` | [`OnFetchFn`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L50) | — | Callback after each fetch. See [Using Callbacks](/guides/callbacks#onfetch) |
 | `onMatch` | [`OnMatchFn`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L56) | — | Callback when URL matches. See [Using Callbacks](/guides/callbacks#onmatch) |
 | `onExists` | [`OnExistsFn`](https://github.com/macieklamberski/feedcanon/blob/main/src/types.ts#L62) | — | Callback when URL exists. See [Using Callbacks](/guides/callbacks#onexists) |

--- a/package.json
+++ b/package.json
@@ -45,15 +45,13 @@
     "entities": "^8.0.0"
   },
   "peerDependencies": {
-    "feedsmith": "^3.0.0-beta.4",
-    "urlpurify": "^1.0.0"
+    "feedsmith": "^3.0.0-beta.4"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "feedsmith": "^3.0.0-beta.4",
     "kvalita": "^1.14.0",
     "tsdown": "^0.22.2",
-    "vitepress": "^2.0.0-alpha.17",
-    "urlpurify": "^1.0.0"
+    "vitepress": "^2.0.0-alpha.17"
   }
 }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,5 +1,4 @@
 import { parseFeed } from 'feedsmith'
-import { defaultTrackingParams } from 'urlpurify'
 import type {
   DefaultParserResult,
   FetchFn,
@@ -18,7 +17,6 @@ export const defaultNormalizeOptions: NormalizeOptions = {
   collapseSlashes: true,
   stripHash: true,
   sortQueryParams: true,
-  stripQueryParams: defaultTrackingParams,
   stripQuery: false,
   stripEmptyQuery: true,
   lowercaseQuery: false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,13 @@ import type {
   Rewrite,
 } from './types.js'
 
+// Stand-in for an injected cleaner (e.g. urlpurify): removes doing_wp_cron.
+const stripWpCron = (url: string): string => {
+  const parsed = new URL(url)
+  parsed.searchParams.delete('doing_wp_cron')
+  return parsed.toString()
+}
+
 describe('findCanonical', () => {
   // Helper that provides type context for options, enabling proper callback typing.
   const toOptions = <T>(o: FindCanonicalOptions<T> & { parser: ParserAdapter<T> }) => o
@@ -426,6 +433,7 @@ describe('findCanonical', () => {
             },
           }),
           parser: createMockParser(undefined),
+          cleanUrlFn: stripWpCron,
         })
 
         expect(await findCanonical(value, options)).toBe(expected)
@@ -443,6 +451,7 @@ describe('findCanonical', () => {
             },
           }),
           parser: createMockParser(undefined),
+          cleanUrlFn: stripWpCron,
         })
 
         expect(await findCanonical(value, options)).toBe(expected)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { defaultTrackingParams } from 'urlpurify'
 import { defaultFetch, defaultParser, defaultTiers } from './defaults.js'
 import type {
   DefaultParserResult,
@@ -37,19 +36,23 @@ export async function findCanonical(
   const {
     parser = defaultParser,
     fetchFn = defaultFetch,
+    cleanUrlFn,
     existsFn,
     tiers = defaultTiers,
     rewrites,
     probes,
-    stripQueryParams = defaultTrackingParams,
     onFetch,
     onMatch,
     onExists,
   } = options ?? {}
 
-  // Strip tracking params from URL using normalizeUrl with minimal options.
+  // Clean the URL with the injected function (when given), then tidy the
+  // remaining query.
   const stripParams = (url: string): string => {
-    return normalizeUrl(url, { stripQueryParams, sortQueryParams: true, stripEmptyQuery: true })
+    return normalizeUrl(cleanUrlFn ? cleanUrlFn(url) : url, {
+      sortQueryParams: true,
+      stripEmptyQuery: true,
+    })
   }
 
   // Prepare a URL by resolving protocols, relative paths, and applying rewrites.

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,11 +68,11 @@ export type FindCanonicalOptions<
 > = {
   parser?: ParserAdapter<TFeed> // Required to extract selfUrl from feed.
   fetchFn?: FetchFn<TResponse>
+  cleanUrlFn?: (url: string) => string // Clean URLs before candidate generation (e.g., strip tracking params).
   existsFn?: ExistsFn<TExisting> // Check if URLs exist in database.
   rewrites?: Array<Rewrite> // URL rewrites (e.g., FeedBurner).
   probes?: Array<Probe> // URL probes (e.g., WordPress query param → path).
   tiers?: Array<Tier> // Normalization tiers (cleanest to least clean).
-  stripQueryParams?: Array<string> // Query params to strip (e.g., utm_*, doing_wp_cron).
   onFetch?: OnFetchFn<TResponse> // Called after each fetch operation.
   onMatch?: OnMatchFn<TFeed, TResponse> // Called when a URL matches the initial response.
   onExists?: OnExistsFn<TExisting> // Called when existsFn finds a URL.

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1277,9 +1277,9 @@ describe('normalizeUrl', () => {
   })
 
   describe('tracking parameter stripping', () => {
-    it('should strip default tracking parameters', () => {
+    it('should keep tracking parameters with default options', () => {
       const value = 'https://example.com/feed?utm_source=twitter&fbclid=abc&id=123'
-      const expected = 'example.com/feed?id=123'
+      const expected = 'example.com/feed?fbclid=abc&id=123&utm_source=twitter'
 
       expect(normalizeUrl(value)).toBe(expected)
     })
@@ -1498,8 +1498,7 @@ describe('normalizeUrl', () => {
 
   describe('combined normalizations', () => {
     it('should apply all default normalizations', () => {
-      const value =
-        'https://user:pass@www.EXAMPLE.COM:443/path//to/feed/?utm_source=test&z=2&a=1#section'
+      const value = 'https://user:pass@www.EXAMPLE.COM:443/path//to/feed/?z=2&a=1#section'
       const expected = 'user:pass@example.com/path/to/feed?a=1&z=2'
 
       expect(normalizeUrl(value)).toBe(expected)


### PR DESCRIPTION
findCanonical no longer carries any tracking-param knowledge. The `stripQueryParams` option is replaced by `cleanUrlFn?: (url: string) => string`, applied once before candidate generation. There is no default: without the option, query params flow through to the tiers untouched (tier 1 still tests the query-less candidate, so fully-tracking URLs keep canonicalizing cleanly). Wire [urlpurify](https://github.com/macieklamberski/urlpurify)'s `stripTrackingParams` (or any custom function) to restore param cleaning, mirroring the `cleanUrlFn` hook feedsweep ships. Users bringing their own function need no extra packages: feedcanon has no urlpurify dependency at all anymore.

`NormalizeOptions.stripQueryParams` survives as a plain exact-string option for structural use (the Blogger rewrite strips functional params like `alt` and `max-results` through it), and `defaultNormalizeOptions` no longer includes any param list: `normalizeUrl` is purely structural by default.

Released as a minor by design. Consumers that relied on default stripping should pass `cleanUrlFn: stripTrackingParams` from urlpurify; consumers that passed `stripQueryParams` should wrap their list: `cleanUrlFn: (url) => stripTrackingParams(url, myParams)`.