### PR TITLE
style: Group consecutive regex constants without blank lines

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,11 +24,9 @@ const ipv6Regex = /^([0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}$/i
 
 // Characters that are safe in URL path segments and don't need percent encoding.
 const safePathCharsRegex = /[a-zA-Z0-9._~!$&'()*+,;=:@-]/
-
 const httpsLetterRegex = /s/i
 const protocolPrefixRegex = /^https?:\/\//
 const wwwPrefixRegex = /^www\./
-
 const httpProtocolRegex = /^http:\/\//i
 const httpsProtocolRegex = /^https:\/\//i
 


### PR DESCRIPTION
Removes the blank lines splitting the run of protocol/URL regex constants in `src/utils.ts` so the consecutive declarations read as one block, per the `*Regex` grouping convention. Whitespace-only; no behavior change.