### PR TITLE
fix: Escape regex metacharacters in neutralized feed host

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2478,4 +2478,29 @@ describe('neutralizeUrls', () => {
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
   })
+
+  describe('regex injection', () => {
+    it('should escape regex metacharacters in host without catastrophic backtracking', () => {
+      // The host comes from feed content. An unescaped `(a+)+` would be a ReDoS
+      // pattern; with a long matching run in the body it must still return quickly.
+      const url = 'http://(a+)+x.com/feed'
+      const value = `"https://${'a'.repeat(40)}!"`
+
+      const start = performance.now()
+      const result = neutralizeUrls(value, [url])
+      const elapsed = performance.now() - start
+
+      expect(elapsed).toBeLessThan(1000)
+      // The literal `(a+)+x.com` host is not present in the body, so nothing is neutralized.
+      expect(result).toBe(value)
+    })
+
+    it('should neutralize a host containing regex metacharacters literally', () => {
+      const url = 'http://a+b.example.com/feed'
+      const value = '{"link":"https://a+b.example.com/post"}'
+      const expected = '{"link":"/post"}'
+
+      expect(neutralizeUrls(value, [url])).toBe(expected)
+    })
+  })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -446,6 +446,8 @@ export const createSignature = <T extends Record<string, unknown>>(
 
 // Pre-compiled pattern for trailing slash normalization.
 const trailingSlashRegex = /("(?:https?:\/\/|\/)[^"]+)\/([?"])/g
+// Regex metacharacters that must be escaped before a host is interpolated into a dynamic pattern.
+const regexMetaCharsRegex = /[.*+?^${}()|[\]\\]/g
 
 export const neutralizeUrls = (text: string, urls: Array<string>): string => {
   // Neutralizes URLs in text to ensure content differing only in URL
@@ -453,7 +455,9 @@ export const neutralizeUrls = (text: string, urls: Array<string>): string => {
 
   const escapeHost = (url: string): string | undefined => {
     try {
-      return new URL('/', url).host.replace(wwwPrefixRegex, '').replaceAll('.', '\\.')
+      // Fully escape regex metacharacters. The host comes from feed content,
+      // so an unescaped metacharacter (e.g. `(a+)+`) would be a ReDoS injection.
+      return new URL('/', url).host.replace(wwwPrefixRegex, '').replace(regexMetaCharsRegex, '\\$&')
     } catch {}
   }
 


### PR DESCRIPTION
## Problem

`neutralizeUrls` builds a dynamic `RegExp` from feed host strings to canonicalize URL forms in the signature text. The host is taken from feed content (`feed.link` / `home_page_url` / `feed_url`), but `escapeHost` only escaped dots — every other regex metacharacter passed through verbatim.

A malicious feed declaring a self/link host like `(a+)+x.com` injects a catastrophic-backtracking pattern. With a matching run in the feed body this is an exponential-time ReDoS that freezes the event loop, reachable from **any subscribed feed**. Measured: ~28 chars → 327ms, ~35 chars → multi-second, doubling per ~2 chars.

## Fix

Escape all regex metacharacters (`.*+?^${}()|[]\`) before interpolating the host into the pattern. The previous dot-only escaping is subsumed.

## Tests

- Pathological `(a+)+x.com` host with a 40-char body run completes in <1s.
- A host that legitimately contains a metacharacter (`a+b.example.com`) is still neutralized correctly.