### PR TITLE
fix: Match feed host case-insensitively when neutralizing URLs

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2477,5 +2477,13 @@ describe('neutralizeUrls', () => {
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
+
+    it('should normalize same-domain URL when host is uppercased in the body', () => {
+      const url = 'https://example.com/feed'
+      const value = '{"link":"http://EXAMPLE.COM/post/1"}'
+      const expected = '{"link":"/post/1"}'
+
+      expect(neutralizeUrls(value, [url])).toBe(expected)
+    })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -464,7 +464,10 @@ export const neutralizeUrls = (text: string, urls: Array<string>): string => {
 
   const hostPattern = hosts.length === 1 ? hosts[0] : `(?:${hosts.join('|')})`
 
+  // Case-insensitive: hosts are case-insensitive per RFC 3986, and `escapeHost`
+  // already lowercased them via the URL parser, so a host appearing uppercased
+  // in the feed body must still be neutralized.
   return text
-    .replace(new RegExp(`https?://(?:www\\.)?${hostPattern}(?=[/"]|\\\\")(/)?`, 'g'), '/')
+    .replace(new RegExp(`https?://(?:www\\.)?${hostPattern}(?=[/"]|\\\\")(/)?`, 'gi'), '/')
     .replace(trailingSlashRegex, '$1$2')
 }


### PR DESCRIPTION
## Problem

`neutralizeUrls` compiled its dynamic host pattern with only the `g` flag, but `escapeHost` lowercases the host (via `URL.host`). A feed body that emits the host in mixed/upper case — `http://EXAMPLE.COM/feed`, legal and common from legacy CMSes — was therefore not neutralized. The two otherwise-identical feeds produce different signatures, so the cleaner URL is rejected at the signature-compare step and canonicalization silently fails.

## Fix

Compile the pattern with `gi`. The escaped host contains no case-sensitive constructs, so this is safe.

## Tests

- An uppercased host in the body now neutralizes to the same root-relative form as the lowercase host.