### PR TITLE
fix: Reject feed URLs carrying userinfo

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -512,9 +512,8 @@ describe('findCanonical', () => {
         expect(await findCanonical(value, options)).toBe(expected)
       })
 
-      it('should preserve credentials added by redirect', async () => {
+      it('should reject a redirect that adds credentials', async () => {
         const value = 'https://example.com/feed'
-        const expected = 'https://user:token@example.com/feed'
         const body = '<feed></feed>'
         const options = toOptions({
           fetchFn: createMockFetch({
@@ -524,7 +523,7 @@ describe('findCanonical', () => {
           parser: createMockParser(undefined),
         })
 
-        expect(await findCanonical(value, options)).toBe(expected)
+        expect(await findCanonical(value, options)).toBeUndefined()
       })
 
       it('should preserve non-standard port from redirect', async () => {
@@ -1757,9 +1756,9 @@ describe('findCanonical', () => {
         expect(await findCanonical(value, options)).toBe(expected)
       })
 
-      it('should use self URL with credentials when it validates', async () => {
+      it('should ignore a self URL with credentials and fall back to the bare host', async () => {
         const value = 'https://example.com/feed'
-        const expected = 'https://user:pass@example.com/feed'
+        const expected = 'https://example.com/feed'
         const body = '<feed></feed>'
         const options = toOptions({
           fetchFn: createMockFetch({

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -665,10 +665,18 @@ describe('resolveUrl', () => {
       expect(resolveUrl(value)).toBe(value)
     })
 
-    it('should preserve authentication credentials', () => {
+    it('should reject authentication credentials', () => {
       const value = 'https://user:pass@example.com/feed.xml'
 
-      expect(resolveUrl(value)).toBe(value)
+      expect(resolveUrl(value)).toBeUndefined()
+    })
+
+    it('should reject userinfo injected via an HTML entity', () => {
+      // `&commat;` decodes to `@`, turning the real host into userinfo so the
+      // string reads as good.com while the host is actually evil.com.
+      const value = 'https://good.com&commat;evil.com/feed.xml'
+
+      expect(resolveUrl(value)).toBeUndefined()
     })
 
     it('should preserve non-standard ports', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,6 +238,14 @@ export const resolveUrl = (url: string, base?: string): string | undefined => {
       return
     }
 
+    // Reject userinfo. A feed self URL like `https://good.com&commat;evil.com/feed`
+    // decodes to `https://good.com@evil.com/feed`, whose actual host is evil.com
+    // while the string reads as good.com. Public feeds never carry credentials, so
+    // refusing them removes the host-confusion entirely.
+    if (parsed.username || parsed.password) {
+      return
+    }
+
     return parsed.href
   } catch {}
 }


### PR DESCRIPTION
## Problem

In a URL, `@` separates userinfo from the host: in `https://good.com@evil.com/feed` the host is **evil.com** and `good.com` is a username. A malicious feed can smuggle the `@` past the eye with an HTML entity in its self URL — `https://good.com&commat;evil.com/feed` (also `&#64;`, `&#x40;`, all terminated so `decodeHTMLStrict` expands them) — which `resolveUrl` decodes to a URL whose true host is evil.com while the string reads as good.com.

This is not a content hijack (the candidate is still content-verified before it can win), but the resolved string is what consumers store, display, and dedupe on, so a feed-reader UI would show the victim domain.

## Fix

`resolveUrl` returns `undefined` when the resolved URL carries any userinfo. Public feeds never legitimately carry credentials, so refusing them removes the host-confusion class entirely — covering both the entity-injected `@` and any literal `user:pass@`.

## Behavior changes

- A self URL with credentials is ignored; canonicalization falls back to the bare host.
- A redirect whose final URL adds credentials is rejected (the call returns `undefined`).

Existing tests asserting credentials are preserved are updated to the new reject behavior.