### PR TITLE
fix: Reject backslash-introduced authorities when resolving URLs

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -737,6 +737,28 @@ describe('resolveUrl', () => {
     })
   })
 
+  describe('backslash authority rejection', () => {
+    const base = 'https://good.com/blog/'
+
+    it('should reject a backslash protocol-relative authority', () => {
+      expect(resolveUrl('\\\\evil.com', base)).toBeUndefined()
+      expect(resolveUrl('\\\\evil.com')).toBeUndefined()
+    })
+
+    it('should reject a mixed slash-backslash authority', () => {
+      expect(resolveUrl('/\\evil.com', base)).toBeUndefined()
+      expect(resolveUrl('\\/evil.com', base)).toBeUndefined()
+    })
+
+    it('should reject a backslash authority decoded from an HTML entity', () => {
+      expect(resolveUrl('&bsol;&bsol;evil.com', base)).toBeUndefined()
+    })
+
+    it('should still resolve a legitimate protocol-relative URL', () => {
+      expect(resolveUrl('//cdn.example.com/feed', base)).toBe('https://cdn.example.com/feed')
+    })
+  })
+
   describe('bare domains', () => {
     it('should add https:// to bare domain', () => {
       const value = 'example.com/feed.xml'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,8 @@ const protocolPrefixRegex = /^https?:\/\//
 const wwwPrefixRegex = /^www\./
 const httpProtocolRegex = /^http:\/\//i
 const httpsProtocolRegex = /^https:\/\//i
+// Protocol-relative authority introduced by a backslash (`\\host`, `/\host`, `\/host`).
+const backslashAuthorityRegex = /^\s*(?:\\[/\\]|\/\\)/
 
 // Pre-compiled patterns for fixMalformedProtocol.
 // Fast path: valid http(s):// followed by hostname char (excludes lone 'w' to avoid partial 'www').
@@ -210,6 +212,14 @@ export const resolveUrl = (url: string, base?: string): string | undefined => {
   // expands entities with a trailing semicolon, so a query parameter whose name matches an
   // entity (e.g. `?id=1&copy=2`) is left intact instead of being mangled into `?id=1©=2`.
   resolvedUrl = url.includes('&') ? decodeHTMLStrict(url) : url
+
+  // Step 1b: Reject protocol-relative authorities introduced by a backslash. The WHATWG
+  // parser treats `\` as `/`, so `\\evil.com` or `/\evil.com` resolved against a base would
+  // rebase onto an attacker-named host. Legitimate protocol-relative URLs (`//host`) and
+  // malformed protocols repaired later (`http:\\host`) are unaffected.
+  if (backslashAuthorityRegex.test(resolvedUrl)) {
+    return
+  }
 
   // Step 2: Convert feed-related protocols.
   resolvedUrl = resolveFeedProtocol(resolvedUrl)


### PR DESCRIPTION
## Problem

The WHATWG URL parser treats `\` as `/` for special schemes. A feed self URL of `\\evil.com` or `/\evil.com`, resolved against the feed's base, therefore rebases onto an attacker-named host (`https://evil.com/`) rather than staying on the serving host. The same applies to a backslash authority smuggled in via an HTML entity (`&bsol;&bsol;evil.com`).

As with the userinfo case, the candidate is still content-verified before it can win, so this is not a content hijack — the risk is the resolved string that consumers store and display.

## Fix

`resolveUrl` rejects (returns `undefined`) when the URL — after entity decoding — begins with a protocol-relative authority introduced by a backslash (`\\host`, `/\host`, `\/host`).

Deliberately narrow, to avoid breaking established behavior:
- Legitimate protocol-relative URLs (`//cdn.example.com`) still resolve, so CDN-hosted self links keep working.
- Malformed protocols repaired downstream (`http:\\host` → `http://host`) are unaffected.
- A single leading backslash (`\evil.com`) already stays on the base host as a path and is left alone.
- Backslashes inside the path (`https://host\feed\rss.xml`) are still normalized to slashes.