### PR TITLE
refactor: Build signature without mutating the parsed feed

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -289,24 +289,34 @@ export const defaultParser: ParserAdapter<DefaultParserResult> = {
       contentUrl = parsed.feed.home_page_url
       signature = createSignature(parsed.feed, ['feed_url'])
     } else {
+      // The self link is nested, so it is temporarily cleared rather than excluded by
+      // createSignature (which only omits top-level fields). The finally restores it even
+      // if serialization throws, so the input feed object is never left mutated.
       const selfLink = retrieveSelfLink(parsed)
       const savedSelfHref = selfLink?.href
       if (selfLink) {
         selfLink.href = undefined
       }
 
-      if (parsed.format === 'rss') {
-        contentUrl = parsed.feed.link
-        signature = createSignature(parsed.feed, ['lastBuildDate', 'pubDate', 'link', 'generator'])
-      } else if (parsed.format === 'rdf') {
-        contentUrl = parsed.feed.link
-        signature = createSignature(parsed.feed, ['link'])
-      } else {
-        signature = createSignature(parsed.feed, ['updated', 'generator'])
-      }
-
-      if (selfLink) {
-        selfLink.href = savedSelfHref
+      try {
+        if (parsed.format === 'rss') {
+          contentUrl = parsed.feed.link
+          signature = createSignature(parsed.feed, [
+            'lastBuildDate',
+            'pubDate',
+            'link',
+            'generator',
+          ])
+        } else if (parsed.format === 'rdf') {
+          contentUrl = parsed.feed.link
+          signature = createSignature(parsed.feed, ['link'])
+        } else {
+          signature = createSignature(parsed.feed, ['updated', 'generator'])
+        }
+      } finally {
+        if (selfLink) {
+          selfLink.href = savedSelfHref
+        }
       }
     }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1992,6 +1992,26 @@ describe('createSignature', () => {
 
     expect(createSignature(value, [])).toBe(expected)
   })
+
+  it('should omit only top-level fields, not same-named nested keys', () => {
+    const value = {
+      link: 'https://example.com/feed',
+      items: [{ link: 'https://example.com/post' }],
+    }
+    const expected = JSON.stringify({ items: [{ link: 'https://example.com/post' }] })
+
+    expect(createSignature(value, ['link'])).toBe(expected)
+  })
+
+  it('should leave the object intact when serialization throws', () => {
+    // BigInt is not serializable, so JSON.stringify throws. Because no field is mutated,
+    // the input object is unchanged — the prior implementation left it corrupted.
+    const value: Record<string, unknown> = { title: 'Test', big: 1n }
+
+    expect(() => createSignature(value, ['title'])).toThrow()
+    expect(value.title).toBe('Test')
+    expect(value.big).toBe(1n)
+  })
 })
 
 describe('neutralizeUrls', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,19 +429,15 @@ export const createSignature = <T extends Record<string, unknown>>(
   object: T,
   fields: Array<keyof T>,
 ): string => {
-  const saved = fields.map((key) => [key, object[key]] as const)
+  const excluded = new Set(fields)
 
-  for (const key of fields) {
-    object[key] = undefined as T[keyof T]
-  }
-
-  const signature = JSON.stringify(object)
-
-  for (const [key, val] of saved) {
-    object[key] = val as T[keyof T]
-  }
-
-  return signature
+  // Omit the named top-level fields via a replacer instead of mutating the object.
+  // `this` is the holder of each property, so `this === object` matches only the
+  // root's own fields, leaving same-named keys on nested items untouched. This keeps
+  // the input feed object intact even if serialization throws, and adds no copy.
+  return JSON.stringify(object, function (this: unknown, key, value) {
+    return this === object && excluded.has(key as keyof T) ? undefined : value
+  })
 }
 
 // Static pattern that locates the start of each absolute HTTP(S) URL in feed text.


### PR DESCRIPTION
## Problem

`createSignature` excluded fields from the signature by setting them to `undefined`, calling `JSON.stringify`, then restoring them. If `JSON.stringify` threw mid-way — e.g. a `BigInt` value from a custom parser adapter — the restore loop never ran, leaving the **shared** parsed feed object permanently corrupted. That same object is passed to every `onMatch` consumer.

## Fix

Exclude the named top-level fields with a `JSON.stringify` **replacer** keyed on object identity (`this === object`) instead of mutating:

```ts
const excluded = new Set(fields)
return JSON.stringify(object, function (this: unknown, key, value) {
  return this === object && excluded.has(key as keyof T) ? undefined : value
})
```

- **No mutation** — the input feed is never altered, so it can't be corrupted on throw and `onMatch` consumers always see it intact.
- **No copy** — `JSON.stringify` walks the object once (as before); the only extra allocation is the small `Set` of field names, so memory on large feeds is unchanged.
- `this === object` matches only the root's own properties, so same-named keys on nested items are left in the signature exactly as before.

The nested self-link clearing in `getSignature` (which `createSignature` can't reach, since it only omits top-level fields) is wrapped in `try/finally` for the same restore-on-throw guarantee.

## Tests

- Top-level field is omitted while a same-named nested key is preserved.
- The object is left intact after a throwing serialization (`BigInt`) — the prior implementation left it corrupted.