### PR TITLE
fix: Port recent security and correctness fixes from main

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -68,24 +68,34 @@ export const defaultParser: ParserAdapter<DefaultParserResult> = {
       contentUrl = parsed.feed.home_page_url
       signature = createSignature(parsed.feed, ['feed_url'])
     } else {
+      // The self link is nested, so it is temporarily cleared rather than excluded by
+      // createSignature (which only omits top-level fields). The finally restores it even
+      // if serialization throws, so the input feed object is never left mutated.
       const selfLink = retrieveSelfLink(parsed)
       const savedSelfHref = selfLink?.href
       if (selfLink) {
         selfLink.href = undefined
       }
 
-      if (parsed.format === 'rss') {
-        contentUrl = parsed.feed.link
-        signature = createSignature(parsed.feed, ['lastBuildDate', 'pubDate', 'link', 'generator'])
-      } else if (parsed.format === 'rdf') {
-        contentUrl = parsed.feed.link
-        signature = createSignature(parsed.feed, ['link'])
-      } else {
-        signature = createSignature(parsed.feed, ['updated', 'generator'])
-      }
-
-      if (selfLink) {
-        selfLink.href = savedSelfHref
+      try {
+        if (parsed.format === 'rss') {
+          contentUrl = parsed.feed.link
+          signature = createSignature(parsed.feed, [
+            'lastBuildDate',
+            'pubDate',
+            'link',
+            'generator',
+          ])
+        } else if (parsed.format === 'rdf') {
+          contentUrl = parsed.feed.link
+          signature = createSignature(parsed.feed, ['link'])
+        } else {
+          signature = createSignature(parsed.feed, ['updated', 'generator'])
+        }
+      } finally {
+        if (selfLink) {
+          selfLink.href = savedSelfHref
+        }
       }
     }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -654,6 +654,18 @@ describe('resolveUrl', () => {
 
       expect(resolveUrl(value)).toBe(expected)
     })
+
+    it('should not decode a query parameter whose name matches an entity', () => {
+      const value = 'https://example.com/feed?id=1&copy=2&reg=us'
+
+      expect(resolveUrl(value)).toBe(value)
+    })
+
+    it('should not decode an unterminated entity in the query', () => {
+      const value = 'https://example.com/feed?a=1&sect=2&times=3'
+
+      expect(resolveUrl(value)).toBe(value)
+    })
   })
 
   describe('standard HTTP/HTTPS URLs', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2563,6 +2563,14 @@ describe('neutralizeUrls', () => {
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
+
+    it('should normalize same-domain URL when host is uppercased in the body', () => {
+      const url = 'https://example.com/feed'
+      const value = '{"link":"http://EXAMPLE.COM/post/1"}'
+      const expected = '{"link":"/post/1"}'
+
+      expect(neutralizeUrls(value, [url])).toBe(expected)
+    })
   })
 
   describe('regex injection', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2564,4 +2564,29 @@ describe('neutralizeUrls', () => {
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
   })
+
+  describe('regex injection', () => {
+    it('should escape regex metacharacters in host without catastrophic backtracking', () => {
+      // The host comes from feed content. An unescaped `(a+)+` would be a ReDoS
+      // pattern; with a long matching run in the body it must still return quickly.
+      const url = 'http://(a+)+x.com/feed'
+      const value = `"https://${'a'.repeat(40)}!"`
+
+      const start = performance.now()
+      const result = neutralizeUrls(value, [url])
+      const elapsed = performance.now() - start
+
+      expect(elapsed).toBeLessThan(1000)
+      // The literal `(a+)+x.com` host is not present in the body, so nothing is neutralized.
+      expect(result).toBe(value)
+    })
+
+    it('should neutralize a host containing regex metacharacters literally', () => {
+      const url = 'http://a+b.example.com/feed'
+      const value = '{"link":"https://a+b.example.com/post"}'
+      const expected = '{"link":"/post"}'
+
+      expect(neutralizeUrls(value, [url])).toBe(expected)
+    })
+  })
 })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2063,10 +2063,24 @@ describe('createSignature', () => {
     expect(createSignature(value, [])).toBe(expected)
   })
 
-  it.todo('should restore fields when JSON.stringify throws on circular reference', () => {
-    // Object contains a circular reference, so JSON.stringify throws after the fields were already
-    // neutralized. The current implementation has no try/finally around the stringify, so the
-    // saved values are never restored. Potential source bug.
+  it('should omit only top-level fields, not same-named nested keys', () => {
+    const value = {
+      link: 'https://example.com/feed',
+      items: [{ link: 'https://example.com/post' }],
+    }
+    const expected = JSON.stringify({ items: [{ link: 'https://example.com/post' }] })
+
+    expect(createSignature(value, ['link'])).toBe(expected)
+  })
+
+  it('should leave the object intact when serialization throws', () => {
+    // BigInt is not serializable, so JSON.stringify throws. Because no field is mutated,
+    // the input object is unchanged — the prior implementation left it corrupted.
+    const value: Record<string, unknown> = { title: 'Test', big: 1n }
+
+    expect(() => createSignature(value, ['title'])).toThrow()
+    expect(value.title).toBe('Test')
+    expect(value.big).toBe(1n)
   })
 })
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2398,26 +2398,28 @@ describe('neutralizeUrls', () => {
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
 
-    it('should preserve URLs embedded in text (not standalone JSON values)', () => {
+    it('should neutralize own-host URLs embedded in text', () => {
+      // Preserving these would make a feed templating its own www vs non-www host
+      // into prose produce different signatures, so they are neutralized too.
       const url = 'https://example.com/feed'
       const value = JSON.stringify({ description: 'Visit https://example.com for more' })
-      const expected = JSON.stringify({ description: 'Visit https://example.com for more' })
+      const expected = JSON.stringify({ description: 'Visit / for more' })
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
 
-    it('should preserve bare domain followed by space in text', () => {
+    it('should neutralize a bare own-host domain followed by a space', () => {
       const url = 'https://example.com/feed'
       const value = JSON.stringify({ text: 'Check https://example.com now' })
-      const expected = JSON.stringify({ text: 'Check https://example.com now' })
+      const expected = JSON.stringify({ text: 'Check / now' })
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
 
-    it('should preserve URLs with authentication', () => {
+    it('should neutralize own-host URLs carrying authentication', () => {
       const url = 'https://example.com/feed'
       const value = JSON.stringify({ link: 'https://user:pass@example.com/path' })
-      const expected = JSON.stringify({ link: 'https://user:pass@example.com/path' })
+      const expected = JSON.stringify({ link: '/path' })
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
@@ -2566,17 +2568,17 @@ describe('neutralizeUrls', () => {
 
     it('should normalize same-domain URL when host is uppercased in the body', () => {
       const url = 'https://example.com/feed'
-      const value = '{"link":"http://EXAMPLE.COM/post/1"}'
-      const expected = '{"link":"/post/1"}'
+      const value = JSON.stringify({ link: 'http://EXAMPLE.COM/post/1' })
+      const expected = JSON.stringify({ link: '/post/1' })
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })
   })
 
   describe('regex injection', () => {
-    it('should escape regex metacharacters in host without catastrophic backtracking', () => {
-      // The host comes from feed content. An unescaped `(a+)+` would be a ReDoS
-      // pattern; with a long matching run in the body it must still return quickly.
+    it('should not backtrack catastrophically on a host with regex metacharacters', () => {
+      // The host comes from feed content. Were it interpolated into a pattern, `(a+)+`
+      // would be a ReDoS; host matching parses tokens instead, so this returns quickly.
       const url = 'http://(a+)+x.com/feed'
       const value = `"https://${'a'.repeat(40)}!"`
 
@@ -2591,8 +2593,8 @@ describe('neutralizeUrls', () => {
 
     it('should neutralize a host containing regex metacharacters literally', () => {
       const url = 'http://a+b.example.com/feed'
-      const value = '{"link":"https://a+b.example.com/post"}'
-      const expected = '{"link":"/post"}'
+      const value = JSON.stringify({ link: 'https://a+b.example.com/post' })
+      const expected = JSON.stringify({ link: '/post' })
 
       expect(neutralizeUrls(value, [url])).toBe(expected)
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -446,6 +446,8 @@ export const createSignature = <T extends Record<string, unknown>>(
 
 // Pre-compiled pattern for trailing slash normalization.
 const trailingSlashRegex = /("(?:https?:\/\/|\/)[^"]+)\/([?"])/g
+// Regex metacharacters that must be escaped before a host is interpolated into a dynamic pattern.
+const regexMetaCharsRegex = /[.*+?^${}()|[\]\\]/g
 
 export const neutralizeUrls = (text: string, urls: Array<string>): string => {
   // Neutralizes URLs in text to ensure content differing only in URL
@@ -453,7 +455,9 @@ export const neutralizeUrls = (text: string, urls: Array<string>): string => {
 
   const escapeHost = (url: string): string | undefined => {
     try {
-      return new URL('/', url).host.replace(wwwPrefixRegex, '').replaceAll('.', '\\.')
+      // Fully escape regex metacharacters. The host comes from feed content,
+      // so an unescaped metacharacter (e.g. `(a+)+`) would be a ReDoS injection.
+      return new URL('/', url).host.replace(wwwPrefixRegex, '').replace(regexMetaCharsRegex, '\\$&')
     } catch {}
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { decodeHTML } from 'entities'
+import { decodeHTMLStrict } from 'entities'
 import { defaultNormalizeOptions } from './defaults.js'
 import type { MaybePromise, NormalizeOptions, Probe, Rewrite } from './types.js'
 
@@ -206,8 +206,10 @@ export const resolveUrl = (url: string, base?: string): string | undefined => {
   let resolvedUrl: string | undefined
 
   // Step 1: Decode HTML entities to recover the intended URL.
-  // URLs in XML/HTML are often entity-encoded (e.g., &amp; for &).
-  resolvedUrl = url.includes('&') ? decodeHTML(url) : url
+  // URLs in XML/HTML are often entity-encoded (e.g., &amp; for &). Strict decoding only
+  // expands entities with a trailing semicolon, so a query parameter whose name matches an
+  // entity (e.g. `?id=1&copy=2`) is left intact instead of being mangled into `?id=1©=2`.
+  resolvedUrl = url.includes('&') ? decodeHTMLStrict(url) : url
 
   // Step 2: Convert feed-related protocols.
   resolvedUrl = resolveFeedProtocol(resolvedUrl)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -444,34 +444,71 @@ export const createSignature = <T extends Record<string, unknown>>(
   return signature
 }
 
-// Pre-compiled pattern for trailing slash normalization.
+// Static pattern that locates the start of each absolute HTTP(S) URL in feed text.
+// Fixed and never built from feed input, so it carries no ReDoS risk. A URL token runs
+// from a match to the next delimiter (quote, whitespace, angle bracket, backslash, `}`).
+const urlSchemeRegex = /https?:\/\//gi
+const urlDelimiterRegex = /[\s"'<>\\}]/
+// Strips a trailing slash from any URL or root-relative path before a quote or query.
+// Static and linear (the prior ReDoS lived only in the per-host pattern, now removed).
 const trailingSlashRegex = /("(?:https?:\/\/|\/)[^"]+)\/([?"])/g
-// Regex metacharacters that must be escaped before a host is interpolated into a dynamic pattern.
-const regexMetaCharsRegex = /[.*+?^${}()|[\]\\]/g
+
+const neutralizeHost = (url: string): string | undefined => {
+  try {
+    return new URL(url).host.replace(wwwPrefixRegex, '').toLowerCase()
+  } catch {}
+}
 
 export const neutralizeUrls = (text: string, urls: Array<string>): string => {
-  // Neutralizes URLs in text to ensure content differing only in URL
-  // forms (http/https, www/non-www, trailing slash) produces identical output.
-
-  const escapeHost = (url: string): string | undefined => {
-    try {
-      // Fully escape regex metacharacters. The host comes from feed content,
-      // so an unescaped metacharacter (e.g. `(a+)+`) would be a ReDoS injection.
-      return new URL('/', url).host.replace(wwwPrefixRegex, '').replace(regexMetaCharsRegex, '\\$&')
-    } catch {}
-  }
-
-  const hosts = urls.map(escapeHost).filter(Boolean)
-  if (hosts.length === 0) {
+  // Rewrites each occurrence of a feed's own URL to a root-relative form, so content
+  // differing only in URL form (http/https, www/non-www, trailing slash, host casing)
+  // produces identical output. Each URL is located by scanning for the scheme and parsed
+  // with the URL API for host comparison — the feed-supplied host is never interpolated
+  // into a pattern, which is what previously made this a ReDoS injection point.
+  const hosts = new Set(urls.map(neutralizeHost).filter(Boolean))
+  if (hosts.size === 0) {
     return text
   }
 
-  const hostPattern = hosts.length === 1 ? hosts[0] : `(?:${hosts.join('|')})`
+  let result = ''
+  let lastIndex = 0
+  urlSchemeRegex.lastIndex = 0
 
-  // Case-insensitive: hosts are case-insensitive per RFC 3986, and `escapeHost`
-  // already lowercased them via the URL parser, so a host appearing uppercased
-  // in the feed body must still be neutralized.
-  return text
-    .replace(new RegExp(`https?://(?:www\\.)?${hostPattern}(?=[/"]|\\\\")(/)?`, 'gi'), '/')
-    .replace(trailingSlashRegex, '$1$2')
+  for (let match = urlSchemeRegex.exec(text); match; match = urlSchemeRegex.exec(text)) {
+    const start = match.index
+
+    // Skip schemes inside a URL that was already rewritten (e.g. a nested URL in a query).
+    if (start < lastIndex) {
+      continue
+    }
+
+    let end = start
+    while (end < text.length && !urlDelimiterRegex.test(text[end])) {
+      end++
+    }
+
+    let parsed: URL
+    try {
+      parsed = new URL(text.slice(start, end))
+    } catch {
+      continue
+    }
+
+    if (!hosts.has(parsed.host.replace(wwwPrefixRegex, '').toLowerCase())) {
+      continue
+    }
+
+    // Root-relative form with the trailing slash collapsed (the root path stays `/`).
+    let path = parsed.pathname
+    if (path.length > 1 && path.endsWith('/')) {
+      path = path.slice(0, -1)
+    }
+
+    result += text.slice(lastIndex, start) + path + parsed.search + parsed.hash
+    lastIndex = end
+  }
+
+  result += text.slice(lastIndex)
+
+  return result.replace(trailingSlashRegex, '$1$2')
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -468,7 +468,10 @@ export const neutralizeUrls = (text: string, urls: Array<string>): string => {
 
   const hostPattern = hosts.length === 1 ? hosts[0] : `(?:${hosts.join('|')})`
 
+  // Case-insensitive: hosts are case-insensitive per RFC 3986, and `escapeHost`
+  // already lowercased them via the URL parser, so a host appearing uppercased
+  // in the feed body must still be neutralized.
   return text
-    .replace(new RegExp(`https?://(?:www\\.)?${hostPattern}(?=[/"]|\\\\")(/)?`, 'g'), '/')
+    .replace(new RegExp(`https?://(?:www\\.)?${hostPattern}(?=[/"]|\\\\")(/)?`, 'gi'), '/')
     .replace(trailingSlashRegex, '$1$2')
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,11 +24,9 @@ const ipv6Regex = /^([0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}$/i
 
 // Characters that are safe in URL path segments and don't need percent encoding.
 const safePathCharsRegex = /[a-zA-Z0-9._~!$&'()*+,;=:@-]/
-
 const httpsLetterRegex = /s/i
 const protocolPrefixRegex = /^https?:\/\//
 const wwwPrefixRegex = /^www\./
-
 const httpProtocolRegex = /^http:\/\//i
 const httpsProtocolRegex = /^https:\/\//i
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,19 +429,15 @@ export const createSignature = <T extends Record<string, unknown>>(
   object: T,
   fields: Array<keyof T>,
 ): string => {
-  const saved = fields.map((key) => [key, object[key]] as const)
+  const excluded = new Set(fields)
 
-  for (const key of fields) {
-    object[key] = undefined as T[keyof T]
-  }
-
-  const signature = JSON.stringify(object)
-
-  for (const [key, val] of saved) {
-    object[key] = val as T[keyof T]
-  }
-
-  return signature
+  // Omit the named top-level fields via a replacer instead of mutating the object.
+  // `this` is the holder of each property, so `this === object` matches only the
+  // root's own fields, leaving same-named keys on nested items untouched. This keeps
+  // the input feed object intact even if serialization throws, and adds no copy.
+  return JSON.stringify(object, function (this: unknown, key, value) {
+    return this === object && excluded.has(key as keyof T) ? undefined : value
+  })
 }
 
 // Static pattern that locates the start of each absolute HTTP(S) URL in feed text.


### PR DESCRIPTION
Catches `beta` up to the hardening that landed on `main`. **Stacked on #58** (the test-fixture reformat = main's `5bbf940`); merge #58 first.

Each of main's fixes is **cherry-picked as its own commit with the original message**, so the release changelog lines up with main's:

| commit | main PR |
|--------|---------|
| `style: Group consecutive regex constants without blank lines` | #49 |
| `fix: Decode only terminated entities when resolving urls` | #50 |
| `fix: Escape regex metacharacters in neutralized feed host` | #51 |
| `fix: Match feed host case-insensitively when neutralizing URLs` | #52 |
| `refactor: Neutralize feed URLs structurally instead of by dynamic regex` | #55 |
| `refactor: Build signature without mutating the parsed feed` | #56 |

(`#51`/`#52` are the superseded intermediate steps that `#55` replaces — kept so beta's history mirrors main's exactly.)

## Verification
- **`src/utils.ts` is byte-identical to main** after these commits.
- `getSignature` (in `defaults.ts`) is byte-identical to main.
- 662 pass, 0 fail; typecheck + Biome 2.5 clean on beta's feedsmith-3 stack.

The remaining differences vs main (`defaults.ts` stripped-params, `index.ts`/`types.ts`) are beta's own forward `cleanUrlFn`/urlpurify work — not missed main changes.

## Merge order
1. #58 (reformat) → `beta`
2. this (#57) → `beta`